### PR TITLE
Feature/custom webpack stats loader method

### DIFF
--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -118,7 +118,13 @@ WEBPACK_LOADER = {
         'CACHE': False,
         'BUNDLE_DIR_NAME': 'bundles/',
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats-app2.json'),
-    }
+    },
+    'APP_WITH_CUSTOM_ASSETS_LOADER': {
+        'ASSETS_LOADER_FUNCTION': 'app.tests.test_webpack.custom_asset_loader_for_testing',
+    },
+    'APP_WITH_INVALID_ASSETS_LOADER': {
+        'ASSETS_LOADER_FUNCTION': 'nonexistent.function',
+    },
 }
 
 from django_jinja.builtins import DEFAULT_EXTENSIONS

--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -14,7 +14,11 @@ DEFAULT_CONFIG = {
         # FIXME: Explore usage of fsnotify
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
-        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+        'IGNORE': ['.+\.hot-update.js', '.+\.map'],
+        'ASSETS_LOADER': {
+            'func': 'webpack_loader.utils.load_assets_from_filesystem',
+            'args': {}
+        }
     }
 }
 
@@ -24,6 +28,10 @@ user_config = dict(
     (name, dict(DEFAULT_CONFIG['DEFAULT'], **cfg))
     for name, cfg in user_config.items()
 )
+
+user_config['DEFAULT']['ASSETS_LOADER']['args'] = {
+    'stats_file': user_config['DEFAULT']['STATS_FILE']
+}
 
 for entry in user_config.values():
     entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]

--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -30,9 +30,10 @@ user_config = dict(
     for name, cfg in user_config.items()
 )
 
-user_config['DEFAULT']['ASSETS_LOADER']['args'] = {
-    'stats_file': user_config['DEFAULT']['STATS_FILE']
-}
+if user_config['DEFAULT']['ASSETS_LOADER']['func'] == DEFAULT_CONFIG['DEFAULT']['ASSETS_LOADER']['func']:
+    user_config['DEFAULT']['ASSETS_LOADER']['args'] = {
+        'stats_file': user_config['DEFAULT']['STATS_FILE']
+    }
 
 for entry in user_config.values():
     entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]

--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -16,24 +16,16 @@ DEFAULT_CONFIG = {
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
         'IGNORE': ['.+\.hot-update.js', '.+\.map'],
-        'ASSETS_LOADER': {
-            'func': 'webpack_loader.utils.load_assets_from_filesystem',
-            'args': {}
-        }
-    }
+        'ASSETS_LOADER_FUNCTION': 'webpack_loader.utils.load_assets_from_filesystem',
+    },
 }
 
-user_config = getattr(settings, 'WEBPACK_LOADER', DEFAULT_CONFIG)
+user_specified_entries = getattr(settings, 'WEBPACK_LOADER', {'DEFAULT': {}})
 
 user_config = dict(
     (name, dict(DEFAULT_CONFIG['DEFAULT'], **cfg))
-    for name, cfg in user_config.items()
+    for name, cfg in user_specified_entries.items()
 )
-
-if user_config['DEFAULT']['ASSETS_LOADER']['func'] == DEFAULT_CONFIG['DEFAULT']['ASSETS_LOADER']['func']:
-    user_config['DEFAULT']['ASSETS_LOADER']['args'] = {
-        'stats_file': user_config['DEFAULT']['STATS_FILE']
-    }
 
 for entry in user_config.values():
     entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]

--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -9,6 +9,7 @@ __all__ = ('load_config',)
 DEFAULT_CONFIG = {
     'DEFAULT': {
         'CACHE': not settings.DEBUG,
+        'CACHE_TTL': -1,
         'BUNDLE_DIR_NAME': 'webpack_bundles/',
         'STATS_FILE': 'webpack-stats.json',
         # FIXME: Explore usage of fsnotify

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -25,7 +25,7 @@ class WebpackLoader(object):
         fn = import_string(self.config['ASSETS_LOADER']['func'])
         return fn(**self.config['ASSETS_LOADER']['args'])
 
-    def _is_cache_expired(now):
+    def _is_cache_expired(self, now):
         cache_ttl = self.config['CACHE_TTL']
         if cache_ttl < 0:
             return False
@@ -37,6 +37,7 @@ class WebpackLoader(object):
         if self.config['CACHE']:
             now = int(time.time())
             if self._is_cache_expired(now) or self.name not in self._assets:
+		print('--- fetching webpack-stats: {}'.format(time.ctime()))
                 self._assets[self.name] = self._load_assets()
                 self._cache_timestamp = now
             return self._assets[self.name]

--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -1,9 +1,8 @@
-import json
 import time
-from io import open
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.utils.module_loading import import_string
 
 from .exceptions import (
     WebpackError,
@@ -22,14 +21,8 @@ class WebpackLoader(object):
         self.config = load_config(self.name)
 
     def _load_assets(self):
-        try:
-            with open(self.config['STATS_FILE'], encoding="utf-8") as f:
-                return json.load(f)
-        except IOError:
-            raise IOError(
-                'Error reading {0}. Are you sure webpack has generated '
-                'the file and the path is correct?'.format(
-                    self.config['STATS_FILE']))
+        fn = import_string(self.config['ASSETS_LOADER']['func'])
+        return fn(**self.config['ASSETS_LOADER']['args'])
 
     def get_assets(self):
         if self.config['CACHE']:

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+import json
+from io import open
 from .loader import WebpackLoader
 
 
@@ -11,6 +13,16 @@ def get_loader(config_name):
         _loaders[config_name] = WebpackLoader(config_name)
     return _loaders[config_name]
 
+
+def load_assets_from_filesystem(stats_file):
+    try:
+        with open(stats_file, encoding="utf-8") as f:
+            return json.load(f)
+    except IOError:
+        raise IOError(
+            'Error reading {0}. Are you sure webpack has generated '
+            'the file and the path is correct?'.format(stats_file))
+ 
 
 def _filter_by_extension(bundle, extension):
     '''Return only files with the given extension'''

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -14,7 +14,8 @@ def get_loader(config_name):
     return _loaders[config_name]
 
 
-def load_assets_from_filesystem(stats_file):
+def load_assets_from_filesystem(loader):
+    stats_file = loader.config['STATS_FILE']
     try:
         with open(stats_file, encoding="utf-8") as f:
             return json.load(f)


### PR DESCRIPTION
Work done by @ddouglascarr to enable webpack-stats.json to be retrieved from S3.

Refactored after discussion to simplify function specification, ie we don't need to pass args and kwargs, we just pass the relevant `WebpackLoader` object, which has access to all its config info.