### PR TITLE
Use logger instead of print

### DIFF
--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -11,7 +11,9 @@ from .exceptions import (
     WebpackBundleLookupError
 )
 from .config import load_config
+import logging
 
+logger = logging.getLogger(__name__)
 
 class WebpackLoader(object):
     _assets = {}
@@ -43,7 +45,7 @@ class WebpackLoader(object):
         if self.config['CACHE']:
             now = int(time.time())
             if self._is_cache_expired(now) or self.name not in self._assets:
-                print('--- fetching webpack-stats: {}'.format(time.ctime()))
+                logger.info('--- fetching webpack-stats: {}'.format(time.ctime()))
                 self._assets[self.name] = self._load_assets()
                 self._cache_timestamp = now
             return self._assets[self.name]


### PR DESCRIPTION
a print statement is dumping stuff out in our test console.

This just moves it to a `logger.info()` statement.